### PR TITLE
feat: better support for XDG Base Directory

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -43,7 +43,7 @@ else:
     ErrorDialog("Error", "Your desktop environment is not supported yet.")
     exit(0)
 
-autostart_file = str(Path.home()) + "/.config/autostart/tr.org.pardus.welcome.desktop"
+autostart_file = os.getenv("XDG_CONFIG_HOME",  str(Path.home()) + "/.config") + "/autostart/tr.org.pardus.welcome.desktop"
 
 # In live mode, the application should not welcome the user
 if utils.check_live() and os.path.isfile(autostart_file):

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -43,7 +43,7 @@ else:
     ErrorDialog("Error", "Your desktop environment is not supported yet.")
     exit(0)
 
-autostart_file = os.getenv("XDG_CONFIG_HOME",  str(Path.home()) + "/.config") + "/autostart/tr.org.pardus.welcome.desktop"
+autostart_file = "{}/autostart/tr.org.pardus.welcome.desktop".format(GLib.get_user_config_dir())
 
 # In live mode, the application should not welcome the user
 if utils.check_live() and os.path.isfile(autostart_file):


### PR DESCRIPTION
This PR removes the hardcoded path for the user configuration directory (`$HOME/.config/`) and instead uses the environment variable XDG_CONFIG_HOME.